### PR TITLE
v1.0.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
 IMAGE_NAME = ecs-fluentbit-sidecar
-IMAGE_TAG = 1.0.8-amd64
+IMAGE_TAG = 1.0.9-amd64
 ECR_REGISTRY = public.ecr.aws/logzio
 AWS_REGION = us-east-1
 DOCKERFILE = Dockerfile

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To send logs from your ECS containers to Logz.io with fluentbit logging sidecar,
 ```json
 {
   "name": "log_router",
-  "image": "public.ecr.aws/logzio/ecs-fluentbit-sidecar:1.0.8-amd64",
+  "image": "public.ecr.aws/logzio/ecs-fluentbit-sidecar:1.0.9-amd64",
   "memoryReservation": 100,
   "portMappings": [],
   "essential": true,
@@ -49,8 +49,8 @@ To send logs from your ECS containers to Logz.io with fluentbit logging sidecar,
 ```
 The Fluent Bit image is stored in AWS Public ECR and contains the Logz.io output plugin.
 https://gallery.ecr.aws/logzio/ecs-fluentbit-sidecar
-- amd64: `public.ecr.aws/logzio/ecs-fluentbit-sidecar:1.0.8-amd64`
-- arm64: `public.ecr.aws/logzio/ecs-fluentbit-sidecar:1.0.8-arm64`
+- amd64: `public.ecr.aws/logzio/ecs-fluentbit-sidecar:1.0.9-amd64`
+- arm64: `public.ecr.aws/logzio/ecs-fluentbit-sidecar:1.0.9-arm64`
 
 Ensure you have a matching volume on your application container.
 

--- a/fluentbit/fluent-bit.conf
+++ b/fluentbit/fluent-bit.conf
@@ -15,7 +15,7 @@
     Rotate_Wait       10
     Skip_Long_Lines   On
     Mem_Buf_Limit     50MB
-    multiline.parser  docker,go,java,python,cri,multiline-regex
+    multiline.parser  docker,go,java,python,cri,multiline-json,multiline-start-with-date
     Path_Key          log_file
 
 

--- a/fluentbit/parsers.conf
+++ b/fluentbit/parsers.conf
@@ -4,8 +4,15 @@
     Regex ^(?<data>{.*)
 
 [MULTILINE_PARSER]
-    name          multiline-regex
+    name          multiline-json
     type          regex
     flush_timeout 1000
     rule      "start_state"   "/^\{(\s+)?$/"                    "cont"
     rule      "cont"          "/(.+[,\{\s\w\[\]\"]|.*\})$/"     "cont"
+
+[MULTILINE_PARSER]
+    name          multiline-start-with-date
+    type          regex
+    flush_timeout 1000
+    rule      "start_state"   "/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}.*/"           "cont"
+    rule      "cont"          "/^(?!\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2},\d{3}).*/"     "cont"


### PR DESCRIPTION
- support custom logs that start with dates in format `YYYY-MM-dd HH:mm:ss,SSS`